### PR TITLE
TASK-43: 대시보드 페이지 컴포넌트, 레이아웃 구성 및 퍼블리싱

### DIFF
--- a/src/app/dashboard/[dashboardid]/page.tsx
+++ b/src/app/dashboard/[dashboardid]/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import AddColumnButton from '@/src/components/dashboard/AddColumnButton';
+import ColumnList from '@/src/components/dashboard/ColumnList';
+
+export default function DashBoardPage() {
+  return (
+    <div className="flex flex-col xl:flex-row">
+      <ColumnList />
+      <AddColumnButton />
+    </div>
+  );
+}

--- a/src/components/dashboard/AddColumnButton.tsx
+++ b/src/components/dashboard/AddColumnButton.tsx
@@ -1,0 +1,7 @@
+export default function AddColumnButton() {
+  return (
+    <div className="flex h-[66px] w-full items-center justify-center rounded-md border border-gray-200 bg-white md:h-[70px] xl:ml-5 xl:mt-[58px] xl:w-[354px]">
+      새로운 컬럼 추가하기
+    </div>
+  );
+}

--- a/src/components/dashboard/Card.tsx
+++ b/src/components/dashboard/Card.tsx
@@ -1,0 +1,22 @@
+import Image from 'next/image';
+import mockImg from '@/public/images/codeit_logo.png';
+
+export default function Card() {
+  return (
+    <div className="mt-4 flex flex-col gap-1 rounded-md border border-gray-200 bg-white px-3 pb-[5px] pt-3 md:flex-row md:gap-5 xl:flex-col xl:gap-4">
+      <div className="relative w-full pb-[60%] md:w-[90px] md:pb-[54px] xl:w-full xl:pb-[60%]">
+        <Image src={mockImg} fill alt="카드 이미지" />
+      </div>
+      <div className="w-full flex-col">
+        <p className="pb-2.5 font-lg-16px-medium">할 일 내용</p>
+        <div className="flex w-full flex-col justify-between gap-2 md:flex-row xl:flex-col">
+          <span>태그들</span>
+          <div className="flex items-center justify-between md:grow">
+            <span className="font-xs-12px-medium">날짜</span>
+            <span>작성자프로필</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/Column.tsx
+++ b/src/components/dashboard/Column.tsx
@@ -1,0 +1,36 @@
+import addPurple from '@/public/icons/add_purple.png';
+import Image from 'next/image';
+import setting from '@/public/icons/settings.png';
+import Card from './Card';
+
+export default function Column() {
+  return (
+    <div className="mb-4 w-full min-w-[354px] border-b border-gray-100 px-3 pb-6 xl:mb-0 xl:h-full xl:max-h-[100vh] xl:overflow-scroll xl:border-b-0 xl:border-r">
+      <div className="mb-6 mt-4 flex h-[22px] justify-between">
+        <div className="flex items-center gap-2 rounded-md">
+          <span>컬럼컬러</span>
+          <span className="pr-1 font-2lg-18px-bold">컬럼네임</span>
+          <div className="flex h-5 w-5 items-center justify-center rounded bg-gray-100 text-gray-400 font-xs-12px-medium">
+            2
+          </div>
+        </div>
+        <Image src={setting} width={22} height={22} alt="컬럼 수정 버튼" />
+      </div>
+      <div className="flex h-8 w-full items-center justify-center border border-gray-200 bg-white md:h-10">
+        <div className="flex h-5 w-5 items-center justify-center rounded bg-violet-white md:h-[22px] md:w-[22px]">
+          <Image
+            className="h-4 md:w-4"
+            src={addPurple}
+            alt="카드 추가 버튼"
+            width={14.55}
+            height={14.55}
+          />
+        </div>
+      </div>
+      {/* 배열랜더링 */}
+      <Card />
+      <Card />
+      <Card />
+    </div>
+  );
+}

--- a/src/components/dashboard/ColumnList.tsx
+++ b/src/components/dashboard/ColumnList.tsx
@@ -1,0 +1,11 @@
+import Column from './Column';
+
+export default function ColumnList() {
+  return (
+    <div className="mx-auto flex min-h-[100vh] max-w-[400px] flex-col md:mx-0 md:max-w-full xl:flex-row">
+      <Column />
+      <Column />
+      <Column />
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION


## 📌 작업 내용 요약

- 대시보드 페이지 컴포넌트 분리
- 대시보드 페이지 레이아웃 구성
- 대시보드 페이지 퍼블리싱

## 📝 작업 내용 설명

- 배열로 랜더링하는 Column, Card를 컴포넌트로 분리하였습니다.
- approuter에 로직을 최소화하기위해 Column들을 랜더링하는 ColumnList 컴포넌트를 생성했습니다.
- 반응형 웹 디자인을 적용하고 임시 값을 넣어 퍼블리싱을 했습니다. ( 아이템이 비었을 때 고려 X )

## 📷 스크린샷

![스크린샷 2024-08-30 002203](https://github.com/user-attachments/assets/d04f762a-9cf0-4c13-a1c8-3c3c477d2095)
▲모바일 화면
![스크린샷 2024-08-30 002210](https://github.com/user-attachments/assets/cd099d21-0eb9-4595-9861-0818d1ee502b)
▲모바일 화면 (MaxLength 적용)
![스크린샷 2024-08-30 002221](https://github.com/user-attachments/assets/e6fc0ba9-d22d-4efd-9e16-818c62b21fee)
▲태블릿 화면 (좌우로 많이 길어지나, 사이드바 있을 시 미관이 나쁘지 않으리라 예상)
![스크린샷 2024-08-30 002229](https://github.com/user-attachments/assets/4339b047-68e0-44a4-8705-1668cb60e2e2)
▲데스크탑 화면
![스크린샷 2024-08-30 002311](https://github.com/user-attachments/assets/8df50927-3ec9-4abf-b756-42a1001a56ec)
▲데스크탑 화면 ( 각 컬럼에 스크롤 가능 )
![스크린샷 2024-08-30 002359](https://github.com/user-attachments/assets/5d64c79d-76c7-4dbc-ac6c-e667a24e4df9)
▲데스크탑 화면 ( 이미지가 없는 카드 )

## ☑️ 리뷰 요구 사항

코드는 컴포넌트 분리에 관해서 봐주시고, 퍼블리싱은 스크린샷 이미지를 중심으로 피드백 주심 감사할 것 같습니다.

## 🎫 연관된 Jira 티켓 번호
해당 작업 티켓 : TASK-43
상위 작업 티켓 : TASK-41

## ✅ 체크리스트

[x] 내 코드는 주어진 요구사항을 만족합니다.
[x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
[x] 나는 PR 전에 내 코드를 검토했습니다.
[ ] 내 코드에 이해하기 어려운 부분은 별도로 주석을 추가했습니다.
