### PR TITLE
TASK-75: 로그인 및 회원가입 페이지 병합 후 배포를 위한 PR

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,28 @@
-import Auth from '@components/auth/auth';
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import AuthPage from '@components/Auth/AuthPage';
+import { useRoot } from '@core/contexts/RootContexts';
 
 export default function LoginPage() {
-  return <Auth mode="login" />;
+  const { user } = useRoot();
+  const router = useRouter();
+  const [isChecking, setIsChecking] = useState(true);
+
+  useEffect(() => {
+    if (user) {
+      router.push('/mydashboard');
+    } else {
+      setIsChecking(false);
+    }
+  }, [user, router]);
+
+  if (isChecking) {
+    return null;
+  }
+
+  return <AuthPage mode="login" />;
 }

--- a/src/app/mydashboard/page.tsx
+++ b/src/app/mydashboard/page.tsx
@@ -1,24 +1,10 @@
 'use client';
 
-import { useEffect } from 'react';
-
-import { useRoot } from '@/src/core/contexts/RootContexts';
 import InvitedDashboardList from '@components/MyDashBoard/InvitedDashboardList';
 import JoinedDashboardList from '@components/MyDashBoard/JoinedDashboardList';
 import { MyDashboardProvider } from '@core/contexts/MyDashboardContext';
 
-const AUTH_OBJECT = ['zero@naver.com', 'two@naver.com'];
-
 export default function Mydashboard() {
-  const { login } = useRoot();
-
-  useEffect(() => {
-    const handleLogin = async () => {
-      await login({ email: AUTH_OBJECT[0], password: '12345678' });
-    };
-    handleLogin();
-  }, [login]);
-
   return (
     <MyDashboardProvider>
       <main className="ml-[67px] mt-[60px] flex flex-col gap-12 bg-gray-50 px-6 pt-6 md:ml-[160px] md:mt-[70px] xl:ml-[300px]">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,41 +8,30 @@ import UnAutherHeader from '@components/Common/UnAuthHeader';
 import LandingBottom from '@components/Home/LandingBottom';
 import LandingMain from '@components/Home/LandingMain';
 import LandingTop from '@components/Home/LandingTop';
-// import { useRoot } from '@core/contexts/RootContexts';
-
-// 최신 dev 문제가 생겨 useRoot 이용에 제한이 생겨서
-// 같은 형태의 데이터를 만들어서 사용했습니다.
-
-const { user, dashBoardList } = {
-  user: 0,
-  dashBoardList: {
-    dashboards: [
-      {
-        id: 0,
-      },
-    ],
-  },
-};
+import { useRoot } from '@core/contexts/RootContexts';
 
 export default function Home() {
-  // const { user, dashBoardList} = useRoot();
+  const { user, dashboardid, refreshUser } = useRoot(); // RootContext에서 유저 상태 및 대시보드 ID 가져오기
   const router = useRouter();
 
   useEffect(() => {
-    function handleUserDashboardRedirect() {
-      if (user && dashBoardList.dashboards?.length > 0) {
-        const firstDashboardId = dashBoardList.dashboards[0].id;
-        if (firstDashboardId !== undefined) {
-          router.push(`/dashboard/${firstDashboardId}`);
-        }
-      }
+    if (!user) return;
+
+    // user가 갱신이 필요할 때만 refreshUser 호출
+    if (!user.isRefreshed) {
+      refreshUser(user);
     }
 
-    handleUserDashboardRedirect();
-  }, [router]);
-  // useRoot 사용시 디펜던시 [user, dashBoardList, router]
+    if (dashboardid) {
+      router.push(`/dashboard/${dashboardid}`);
+    } else {
+      router.push('/mydashboard');
+    }
+  }, [user, dashboardid, refreshUser, router]);
 
-  if (user) return null;
+  if (user) {
+    return;
+  }
 
   return (
     <>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,5 +1,28 @@
-import Auth from '@components/auth/auth';
+'use client';
 
-export default function signupPage() {
-  return <Auth mode="signup" />;
+import { useEffect, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import AuthPage from '@components/Auth/AuthPage';
+import { useRoot } from '@core/contexts/RootContexts';
+
+export default function SignupPage() {
+  const { user } = useRoot();
+  const router = useRouter();
+  const [isChecking, setIsChecking] = useState(true);
+
+  useEffect(() => {
+    if (user) {
+      router.push('/mydashboard');
+    } else {
+      setIsChecking(false);
+    }
+  }, [user, router]);
+
+  if (isChecking) {
+    return null;
+  }
+
+  return <AuthPage mode="signup" />;
 }

--- a/src/components/Auth/AuthModal.tsx
+++ b/src/components/Auth/AuthModal.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface ModalProps {
+  message: string;
+  onClose: () => void;
+}
+
+export default function Modal({ message, onClose }: ModalProps) {
+  return (
+    <div className="bg-black fixed inset-0 flex items-center justify-center bg-opacity-50">
+      <div className="rounded-lg bg-white p-6">
+        <p>{message}</p>
+        <button
+          onClick={onClose}
+          className="mt-4 rounded-lg bg-indigo-600 px-4 py-2 text-white"
+        >
+          닫기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Auth/InputField.tsx
+++ b/src/components/Auth/InputField.tsx
@@ -1,0 +1,73 @@
+import { FieldErrors, UseFormRegister } from 'react-hook-form';
+
+import Image from 'next/image';
+
+interface FormValues {
+  nickname: string;
+  email: string;
+  password: string;
+  passwordConfirm?: string;
+  terms?: boolean;
+}
+
+interface InputFieldProps {
+  id: keyof FormValues;
+  type?: string;
+  placeholder: string;
+  autoComplete?: string;
+  register: UseFormRegister<FormValues>;
+  errors: FieldErrors<FormValues>[keyof FormValues] | undefined;
+  validation: object;
+  showPassword?: boolean;
+  setShowPassword?: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function InputField({
+  id,
+  type = 'text',
+  placeholder,
+  autoComplete,
+  showPassword,
+  setShowPassword,
+  register,
+  errors,
+  validation,
+}: InputFieldProps) {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium text-gray-700">
+        {placeholder}
+      </label>
+      <div className="relative">
+        <input
+          id={id}
+          type={showPassword ? 'text' : type}
+          placeholder={placeholder}
+          autoComplete={autoComplete}
+          {...register(id, validation)}
+          className={`mt-1 block w-full rounded-md border bg-white px-3 py-2 focus:outline-none ${
+            errors ? 'border-red' : 'border-[#D9D9D9]'
+          } focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm`}
+        />
+        {type === 'password' && setShowPassword && (
+          <button
+            type="button"
+            onClick={() => setShowPassword(prev => !prev)}
+            className="absolute inset-y-0 right-0 top-1/2 flex -translate-y-1/2 transform items-center px-3"
+            aria-label="Toggle password visibility"
+          >
+            <Image
+              src={`/icons/${
+                showPassword ? 'visibility_off' : 'visibility_on'
+              }.png`}
+              alt={showPassword ? '비밀번호 숨기기' : '비밀번호 표시하기'}
+              width={20}
+              height={20}
+            />
+          </button>
+        )}
+      </div>
+      {errors && <p className="mt-1 text-sm text-red">{errors.message}</p>}
+    </div>
+  );
+}

--- a/src/core/contexts/RootContexts.tsx
+++ b/src/core/contexts/RootContexts.tsx
@@ -60,10 +60,10 @@ export default function RootProvider({ children }: PropsWithChildren) {
   /** 로그인 로직: 로그인 기능을 만들 때 가져가서 사용하세요 */
   const login = useCallback(
     async (body: LoginRequestDto) => {
-      await postAuthLogin(body);
-      await getMe(undefined);
+      const response = await postAuthLogin(body); // 응답을 받음
+      return response; // 응답을 반환
     },
-    [postAuthLogin, getMe]
+    [postAuthLogin]
   );
 
   /** 유저 정보 유지: 새로고침하거나, url입력을 통해 이동할 때 유저정보가 유지되도록 구현 */


### PR DESCRIPTION
## 📌 작업 내용 요약

> 
- Auth 컴포넌트 분리 및 RootContect login 로직 수정
- 로그인, 회원가입 기능 연결
- `마이대시보드` 에 있던 로그인 기능 삭제

## 📝 작업 내용 설명
> 
로그인, 회원가입 기능은 정상 작동하나,
에러 처리에 문제가 있어서 현재 로그인 성공시 `모달` 텍스트 부분에 문제가 있습니다만,
`로그인`, `회원가입`, `리다이렉트` 부분은 정상 작동중입니다.
배포를 위해 모든 문제가 해결되지 않은 상태로 올린 점 양해 부탁드립니다. 🥲

## 📷 스크린샷

> 

## ☑️ 리뷰 요구 사항

> 

## 🎫 연관된 Jira 티켓 번호

> TASK-75

## ✅ 체크리스트

[] 내 코드는 주어진 요구사항을 만족합니다.
[ ] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
[V] 나는 PR 전에 내 코드를 검토했습니다.
[ ] 내 코드에 이해하기 어려운 부분은 별도로 주석을 추가했습니다.
